### PR TITLE
Add Lensta manifest

### DIFF
--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -9,7 +9,7 @@ test.describe("Given a mobile browser", async () => {
     test("Then it should show in order mobile and web apps options", async ({ textPost }) => {
       await textPost.open();
 
-      await expect(textPost.options).toHaveText(["Buttrfly", "Orb", "Lenster"]);
+      await expect(textPost.options).toHaveText(["Buttrfly", "Orb", "Lensta", "Lenster"]);
     });
   });
 });

--- a/e2e/profiles.spec.ts
+++ b/e2e/profiles.spec.ts
@@ -9,7 +9,13 @@ test.describe("Given a Profile link", async () => {
     test("Then it should show relevant app options", async ({ anyProfile }) => {
       await anyProfile.open();
 
-      await expect(anyProfile.options).toHaveText(["LensFrens", "Lenster", "Lenstube", "Riff"]);
+      await expect(anyProfile.options).toHaveText([
+        "LensFrens",
+        "Lensta",
+        "Lenster",
+        "Lenstube",
+        "Riff",
+      ]);
     });
   });
 });
@@ -75,7 +81,13 @@ test.describe("Given a Profile link with `by` attribution param", async () => {
     test("Then it should show the specified app first", async ({ anyProfile }) => {
       await anyProfile.openAsSharedBy("lenster");
 
-      await expect(anyProfile.options).toHaveText(["Lenster", "LensFrens", "Lenstube", "Riff"]);
+      await expect(anyProfile.options).toHaveText([
+        "Lenster",
+        "LensFrens",
+        "Lensta",
+        "Lenstube",
+        "Riff",
+      ]);
     });
   });
 

--- a/e2e/publications.spec.ts
+++ b/e2e/publications.spec.ts
@@ -9,7 +9,7 @@ test.describe("Given a Publication link", async () => {
     test("Then it should show relevant app options", async ({ imagePost }) => {
       await imagePost.open();
 
-      await expect(imagePost.options).toHaveText(["Collectz", "Lenster"]);
+      await expect(imagePost.options).toHaveText(["Collectz", "Lensta", "Lenster"]);
     });
   });
 });

--- a/manifests/lensta.json
+++ b/manifests/lensta.json
@@ -1,0 +1,22 @@
+{
+  "appId": "lensta",
+  "name": "Lensta",
+  "description": "Explore & engage with visual content on Lens",
+  "platform": "web",
+  "icon": {
+    "url": "https://ipfs.filebase.io/ipfs/QmeT6Ekrb7xxUUZ6steARbujszzz7rN1LUKNfhXdZvp3Ma",
+    "_url": "https://app.lensta.xyz/favicon.png",
+    "background": "#000"
+  },
+  "routes": {
+    "home": "https://app.lensta.xyz/",
+    "profile": {
+      "url": "https://app.lensta.xyz/profile/:handle"
+    },
+    "publication": {
+      "url": "https://app.lensta.xyz/post/:id",
+      "supports": ["ARTICLE", "IMAGE", "LINK", "TEXT_ONLY"]
+    }
+  },
+  "twitter": "lenstaxyz"
+}

--- a/manifests/lensta.json
+++ b/manifests/lensta.json
@@ -5,7 +5,6 @@
   "platform": "web",
   "icon": {
     "url": "https://ipfs.filebase.io/ipfs/QmeT6Ekrb7xxUUZ6steARbujszzz7rN1LUKNfhXdZvp3Ma",
-    "_url": "https://app.lensta.xyz/favicon.png",
     "background": "#000"
   },
   "routes": {


### PR DESCRIPTION
Hello, and thanks for creating this!

This PR adds Lensta manifest so that profiles & certain posts (text-only, links, images - anything supported in Lensta) can be linked to Lensta.

E.g.
Profile → https://app.lensta.xyz/profile/cyrildallest.lens
Image Post → https://app.lensta.xyz/post/0x2d0e-0x022d
Text-only Post → https://app.lensta.xyz/post/0x2d0e-0x0324